### PR TITLE
Review

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,6 +56,8 @@ const plugin: Plugin<UnduplicatesPluginInterface> = {
         const response = await (
             await posthog.api.get(`/api/projects/${event.team_id}/events/?${urlParams.toString()}`)
         ).json()
+        
+        // a bit 🍝 no? can we simplify this?
         if (response.results && response.results.length) {
             for (const potentialMatch of response.results as PluginEvent[]) {
                 if (potentialMatch.timestamp === event.timestamp) {


### PR DESCRIPTION
Left a small comment but ultimately I'm not sure I want to get this in - it has the potential to blow up the cache and also I'm looking ahead a bit and would like to avoid `processEvent` doing a lot of async stuff (cache, requests) - we might even remove that in the future.

Instead, why not just override the event UUID in this plugin for the hash that you need and then let CH do the rest?