### PR TITLE
Remove debug logging

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,7 +52,6 @@ function stringifyUUID(arr: Buffer) {
 const plugin: Plugin<UnduplicatesPluginInterface> = {
     processEvent: async (event, { config }) => {
         const stringifiedEvent = stringifyEvent(event)
-        console.debug(`Beginning processing. ${stringifiedEvent}`)
 
         if (!event.timestamp) {
             console.info(


### PR DESCRIPTION
We're reducing logging volumes of many plugins and this one stood out. Removing this single line of debug logging should reduce total amount of bytes logged 2x. :)